### PR TITLE
Add license information for net.minidev:accessors-smart

### DIFF
--- a/src/main/resources/license-data.json
+++ b/src/main/resources/license-data.json
@@ -1657,6 +1657,10 @@
             "license": "Apache-2.0",
             "licenseSource": "data"
         },
+        "net.minidev:accessors-smart": {
+            "license": "Apache-2.0",
+            "licenseSource": "data"
+        },
         "org.apache.tika:tika-parsers": {
             "license": "Apache-2.0",
             "licenseSource": "data"


### PR DESCRIPTION
Add license information for net.minidev:accessors-smart needed for newer version of json-path