### PR TITLE
PLAT-516

### DIFF
--- a/src/main/resources/license-data.json
+++ b/src/main/resources/license-data.json
@@ -8,6 +8,10 @@
             "license": "Apache-2.0",
             "licenseSource": "data"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "license": "Apache-2.0",
+            "licenseSource": "data"
+        },
         "com.github.sommeri:less4j": {
             "license": "Apache-2.0",
             "licenseSource": "data"


### PR DESCRIPTION
Caffeine supersedes the caching support in the Google Guava library with an actively maintained Java 8+ version in standalone form. suport for Google Guava cache has been dropped in version 5.x.x of Spring framework, see: https://jira.spring.io/browse/SPR-13690